### PR TITLE
fix: release script should not fail anymore on missing types (mypy)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ pydoc: ## Run a pydoc server and open the browser
 	poetry run python -m pydoc -b
 
 install: ## Run `poetry install`
-	poetry install
+	poetry install --with types,dev,docs
 
 showdeps: ## run poetry to show deps
 	@echo "CURRENT:"


### PR DESCRIPTION
Yes, that’s pretty much all.