### PR TITLE
Fix async iterator

### DIFF
--- a/examples/scryfall.py
+++ b/examples/scryfall.py
@@ -1,9 +1,12 @@
 from mightstone.app import Mightstone
-from mightstone.ass import aiterator_to_list
 
-scryfall = Mightstone().scryfall
-found = aiterator_to_list(scryfall.search_async("boseiju"))
+m = Mightstone()
+found = list(m.scryfall.search("boseiju"))
 
-print(f"Found {len(found)} instances of Boseiju")
+print("boseiju matches:")
 for card in found:
     print(f" - {card}")
+
+print(f"Found {len(found)} instances of Boseiju")
+
+print(list([x.name for x in m.scryfall.search("thalia")]))

--- a/examples/scryfall_sync.py
+++ b/examples/scryfall_sync.py
@@ -1,0 +1,19 @@
+"""
+This example demonstrate the behavior of Mightstone in a synchronous context
+
+random() method is an alias for random_async() using asgiref’s async_to_sync feature
+search() method is an alias for search_async() using asgiref’s async_to_sync feature
+"""
+
+from mightstone import Mightstone
+from mightstone.services.scryfall import Card
+
+mightstone = Mightstone()
+card = mightstone.scryfall.random()
+
+print(f"The random card is {card.name} ({card.id})")
+
+brushwaggs: list[Card] = mightstone.scryfall.search("brushwagg")
+
+for i, brushwagg in enumerate(brushwaggs):
+    print(f"Brushwagg {i} is {brushwagg.name} from {brushwagg.set_code}")

--- a/src/mightstone/ass/__init__.py
+++ b/src/mightstone/ass/__init__.py
@@ -1,6 +1,7 @@
+import asyncio
 import logging
 from functools import wraps
-from typing import Any, AsyncGenerator, Callable, Coroutine, List, TypeVar, Union
+from typing import Any, AsyncGenerator, Callable, Coroutine, Generator, List, TypeVar
 
 import asyncstdlib
 from asgiref.sync import async_to_sync
@@ -11,7 +12,7 @@ T = TypeVar("T")
 
 
 @async_to_sync
-async def aiterator_to_list(ait: AsyncGenerator[T, Any], limit=100) -> List[T]:
+async def aiterator_to_list(ait: AsyncGenerator[T], limit=100) -> List[T]:
     """
     Transforms an async iterator into a sync list
 
@@ -19,15 +20,17 @@ async def aiterator_to_list(ait: AsyncGenerator[T, Any], limit=100) -> List[T]:
     :param limit: Max item to return
     :return: The list of items
     """
-    return [item async for item in asyncstdlib.islice(ait, limit)]
+
+    if limit:
+        ait = asyncstdlib.islice(ait, limit)
+    return [item async for item in ait]
 
 
 R = TypeVar("R")
 
 
-# TODO: probably bad type returned for AsyncGenerator input
 def synchronize(
-    f: Callable[..., Union[Coroutine[Any, Any, R], AsyncGenerator[R, None]]],
+    f: Callable[..., Coroutine[Any, Any, R]],
     docstring: str = None,
 ) -> Callable[..., R]:
     qname = f"{f.__module__}.{f.__qualname__}"
@@ -36,6 +39,35 @@ def synchronize(
     def inner(*args, **kwargs) -> R:
         executor = async_to_sync(f)
         return executor(*args, **kwargs)
+
+    if docstring:
+        inner.__doc__ = docstring
+    else:
+        inner.__doc__ = (
+            f"Sync version of :func:`~{qname}`, same behavior but "
+            "wrapped by :func:`~asgiref.sync.async_to_sync`."
+        )
+
+    return inner
+
+
+def sync_generator(
+    f: Callable[..., AsyncGenerator[R, None]],
+    docstring: str = None,
+) -> Callable[..., Generator[R, None, None]]:
+    qname = f"{f.__module__}.{f.__qualname__}"
+    loop = asyncio.get_event_loop()
+
+    @wraps(f)
+    def inner(*args, **kwargs) -> Generator[R, None, None]:
+        async_generator = f(*args, **kwargs)
+        try:
+            while True:
+                yield loop.run_until_complete(async_generator.__anext__())
+        except StopAsyncIteration as e:
+            return
+        except Exception as e:
+            raise e
 
     if docstring:
         inner.__doc__ = docstring

--- a/src/mightstone/ass/__init__.py
+++ b/src/mightstone/ass/__init__.py
@@ -12,17 +12,19 @@ T = TypeVar("T")
 
 
 @async_to_sync
-async def aiterator_to_list(ait: AsyncGenerator[T], limit=100) -> List[T]:
+async def aiterator_to_list(agen: AsyncGenerator[T, Any], limit=100) -> List[T]:
     """
     Transforms an async iterator into a sync list
 
-    :param ait: Asynchronous iterator
+    :param agen: Asynchronous iterator
     :param limit: Max item to return
     :return: The list of items
     """
 
     if limit:
-        ait = asyncstdlib.islice(ait, limit)
+        ait = asyncstdlib.islice(agen.__aiter__(), limit)
+    else:
+        ait = agen.__aiter__()
     return [item async for item in ait]
 
 
@@ -64,10 +66,8 @@ def sync_generator(
         try:
             while True:
                 yield loop.run_until_complete(async_generator.__anext__())
-        except StopAsyncIteration as e:
+        except StopAsyncIteration:
             return
-        except Exception as e:
-            raise e
 
     if docstring:
         inner.__doc__ = docstring

--- a/src/mightstone/services/edhrec/api.py
+++ b/src/mightstone/services/edhrec/api.py
@@ -6,7 +6,7 @@ import asyncstdlib
 from httpx import HTTPStatusError
 from pydantic.error_wrappers import ValidationError
 
-from mightstone.ass import synchronize
+from mightstone.ass import sync_generator, synchronize
 from mightstone.services import MightstoneHttpClient, ServiceError
 from mightstone.services.edhrec.models import (
     EdhRecCardItem,
@@ -203,7 +203,7 @@ class EdhRecStatic(MightstoneHttpClient):
             ):
                 yield item
 
-    tribes = synchronize(tribes_async)
+    tribes = sync_generator(tribes_async)
 
     async def themes_async(
         self, identity: Union[EdhRecIdentity, str] = None, limit: int = None
@@ -223,7 +223,7 @@ class EdhRecStatic(MightstoneHttpClient):
             ):
                 yield item
 
-    themes = synchronize(themes_async)
+    themes = sync_generator(themes_async)
 
     async def sets_async(
         self, limit: int = None
@@ -233,7 +233,7 @@ class EdhRecStatic(MightstoneHttpClient):
         ):
             yield item
 
-    sets = synchronize(sets_async)
+    sets = sync_generator(sets_async)
 
     async def salt_async(
         self, year: int = None, limit: int = None
@@ -270,7 +270,7 @@ class EdhRecStatic(MightstoneHttpClient):
         async for item in self._page_item_generator(path, limit=limit):
             yield item
 
-    top_cards = synchronize(top_cards_async)
+    top_cards = sync_generator(top_cards_async)
 
     async def cards_async(
         self,
@@ -327,7 +327,7 @@ class EdhRecStatic(MightstoneHttpClient):
         async for item in self._page_item_generator(path, category, limit=limit):
             yield item
 
-    cards = synchronize(cards_async)
+    cards = sync_generator(cards_async)
 
     async def companions_async(
         self, limit: int = None
@@ -337,7 +337,7 @@ class EdhRecStatic(MightstoneHttpClient):
         ):
             yield item
 
-    companions = synchronize(companions_async)
+    companions = sync_generator(companions_async)
 
     async def partners_async(
         self, identity: Union[EdhRecIdentity, str] = None, limit: int = None
@@ -349,7 +349,7 @@ class EdhRecStatic(MightstoneHttpClient):
         async for item in self._page_item_generator(path, limit=limit):
             yield item
 
-    partners = synchronize(partners_async)
+    partners = sync_generator(partners_async)
 
     async def commanders_async(
         self, identity: Union[EdhRecIdentity, str] = None, limit: int = None
@@ -361,7 +361,7 @@ class EdhRecStatic(MightstoneHttpClient):
         async for item in self._page_item_generator(path, limit=limit):
             yield item
 
-    commanders = synchronize(commanders_async)
+    commanders = sync_generator(commanders_async)
 
     async def combos_async(
         self, identity: Union[EdhRecIdentity, str], limit: int = None
@@ -372,7 +372,7 @@ class EdhRecStatic(MightstoneHttpClient):
         ):
             yield item
 
-    combos = synchronize(combos_async)
+    combos = sync_generator(combos_async)
 
     async def combo_async(
         self, identity: str, identifier: Union[EdhRecIdentity, str], limit: int = None
@@ -383,7 +383,7 @@ class EdhRecStatic(MightstoneHttpClient):
         ):
             yield item
 
-    combo = synchronize(combo_async)
+    combo = sync_generator(combo_async)
 
     async def _page_item_generator(
         self,

--- a/src/mightstone/services/edhrec/api.py
+++ b/src/mightstone/services/edhrec/api.py
@@ -244,7 +244,7 @@ class EdhRecStatic(MightstoneHttpClient):
         async for item in self._page_item_generator(path, limit=limit):
             yield item
 
-    salt = synchronize(salt_async)
+    salt = sync_generator(salt_async)
 
     async def top_cards_async(
         self,

--- a/src/mightstone/services/mtgjson/api.py
+++ b/src/mightstone/services/mtgjson/api.py
@@ -24,7 +24,7 @@ import asyncstdlib
 from httpx import HTTPStatusError
 from pydantic.error_wrappers import ValidationError
 
-from mightstone.ass import compressor, synchronize
+from mightstone.ass import compressor, sync_generator, synchronize
 from mightstone.core import MightstoneModel
 from mightstone.services import MightstoneHttpClient, ServiceError
 from mightstone.services.mtgjson.models import (
@@ -158,7 +158,7 @@ class MtgJson(MightstoneHttpClient):
         ):
             yield item
 
-    all_printings = synchronize(all_printings_async)
+    all_printings = sync_generator(all_printings_async)
 
     async def all_identifiers_async(self) -> AsyncGenerator[Card, None]:
         """
@@ -169,7 +169,7 @@ class MtgJson(MightstoneHttpClient):
         async for k, item in self._iterate_model(kind="AllIdentifiers", model=Card):
             yield item
 
-    all_identifiers = synchronize(all_identifiers_async)
+    all_identifiers = sync_generator(all_identifiers_async)
 
     async def all_prices_async(self) -> AsyncGenerator[CardPrices, None]:
         """
@@ -180,7 +180,7 @@ class MtgJson(MightstoneHttpClient):
         async for k, item in self._iterate_model(kind="AllPrices"):
             yield CardPrices(uuid=k, **item)
 
-    all_prices = synchronize(all_prices_async)
+    all_prices = sync_generator(all_prices_async)
 
     async def atomic_cards_async(self) -> AsyncGenerator[CardAtomic, None]:
         """
@@ -191,7 +191,7 @@ class MtgJson(MightstoneHttpClient):
         async for item in self._atomic(kind="AtomicCards"):
             yield item
 
-    atomic_cards = synchronize(atomic_cards_async)
+    atomic_cards = sync_generator(atomic_cards_async)
 
     async def card_types_async(self) -> CardTypes:
         """
@@ -224,7 +224,7 @@ class MtgJson(MightstoneHttpClient):
         ):
             yield item
 
-    deck_list = synchronize(deck_list_async)
+    deck_list = sync_generator(deck_list_async)
 
     async def deck_async(self, file_name: str) -> Deck:
         """
@@ -267,7 +267,7 @@ class MtgJson(MightstoneHttpClient):
         async for k, item in self._iterate_model(kind="Legacy", model=Set):
             yield item
 
-    legacy = synchronize(legacy_async)
+    legacy = sync_generator(legacy_async)
 
     async def legacy_atomic_async(self) -> AsyncGenerator[CardAtomic, None]:
         """
@@ -279,7 +279,7 @@ class MtgJson(MightstoneHttpClient):
         async for item in self._atomic(kind="LegacyAtomic"):
             yield item
 
-    legacy_atomic = synchronize(legacy_atomic_async)
+    legacy_atomic = sync_generator(legacy_atomic_async)
 
     async def meta_async(self) -> Meta:
         """
@@ -302,7 +302,7 @@ class MtgJson(MightstoneHttpClient):
         async for k, item in self._iterate_model(kind="Modern", model=Set):
             yield item
 
-    modern = synchronize(modern_async)
+    modern = sync_generator(modern_async)
 
     async def modern_atomic_async(self) -> AsyncGenerator[CardAtomic, None]:
         """
@@ -313,7 +313,7 @@ class MtgJson(MightstoneHttpClient):
         async for item in self._atomic(kind="ModernAtomic"):
             yield item
 
-    modern_atomic = synchronize(modern_atomic_async)
+    modern_atomic = sync_generator(modern_atomic_async)
 
     async def pauper_atomic_async(self) -> AsyncGenerator[CardAtomic, None]:
         """
@@ -324,7 +324,7 @@ class MtgJson(MightstoneHttpClient):
         async for item in self._atomic(kind="PauperAtomic"):
             yield item
 
-    pauper_atomic = synchronize(pauper_atomic_async)
+    pauper_atomic = sync_generator(pauper_atomic_async)
 
     async def pioneer_async(self) -> AsyncGenerator[Set, None]:
         """
@@ -336,7 +336,7 @@ class MtgJson(MightstoneHttpClient):
         async for k, item in self._iterate_model(kind="Pioneer", model=Set):
             yield item
 
-    pioneer = synchronize(pioneer_async)
+    pioneer = sync_generator(pioneer_async)
 
     async def pioneer_atomic_async(self) -> AsyncGenerator[CardAtomic, None]:
         """
@@ -347,7 +347,7 @@ class MtgJson(MightstoneHttpClient):
         async for item in self._atomic(kind="PioneerAtomic"):
             yield item
 
-    pioneer_atomic = synchronize(pioneer_atomic_async)
+    pioneer_atomic = sync_generator(pioneer_atomic_async)
 
     async def set_list_async(self) -> AsyncGenerator[SetList, None]:
         """
@@ -360,7 +360,7 @@ class MtgJson(MightstoneHttpClient):
         ):
             yield item
 
-    set_list = synchronize(set_list_async)
+    set_list = sync_generator(set_list_async)
 
     async def set_async(self, code: str) -> SetList:
         """
@@ -385,7 +385,7 @@ class MtgJson(MightstoneHttpClient):
         async for k, item in self._iterate_model(kind="Standard", model=Set):
             yield item
 
-    standard = synchronize(standard_async)
+    standard = sync_generator(standard_async)
 
     async def standard_atomic_async(self) -> AsyncGenerator[CardAtomic, None]:
         """
@@ -396,7 +396,7 @@ class MtgJson(MightstoneHttpClient):
         async for item in self._atomic(kind="StandardAtomic"):
             yield item
 
-    standard_atomic = synchronize(standard_atomic_async)
+    standard_atomic = sync_generator(standard_atomic_async)
 
     async def tcg_player_skus_async(self) -> AsyncGenerator[TcgPlayerSKUs, None]:
         """
@@ -418,7 +418,7 @@ class MtgJson(MightstoneHttpClient):
 
             yield group
 
-    tcg_player_skus = synchronize(tcg_player_skus_async)
+    tcg_player_skus = sync_generator(tcg_player_skus_async)
 
     async def vintage_async(self) -> AsyncGenerator[Set, None]:
         """
@@ -430,7 +430,7 @@ class MtgJson(MightstoneHttpClient):
         async for k, item in self._iterate_model(kind="Vintage", model=Set):
             yield item
 
-    vintage = synchronize(vintage_async)
+    vintage = sync_generator(vintage_async)
 
     async def vintage_atomic_async(self) -> AsyncGenerator[CardAtomic, None]:
         """
@@ -441,7 +441,7 @@ class MtgJson(MightstoneHttpClient):
         async for item in self._atomic(kind="VintageAtomic"):
             yield item
 
-    vintage_atomic = synchronize(vintage_atomic_async)
+    vintage_atomic = sync_generator(vintage_atomic_async)
 
     async def _atomic(self, kind: str) -> AsyncGenerator[CardAtomic, None]:
         card: Optional[CardAtomic] = None

--- a/src/mightstone/services/scryfall/api.py
+++ b/src/mightstone/services/scryfall/api.py
@@ -149,7 +149,9 @@ class Scryfall(MightstoneHttpClient):
         params = {}
         if q:
             params["q"] = q
-        return await self._get_item("/cards/random", Card, params=params)
+        return await self._get_item(
+            "/cards/random", Card, params=params, headers={"cache-control": "no-cache"}
+        )
 
     random = synchronize(random_async)
 

--- a/src/mightstone/services/scryfall/api.py
+++ b/src/mightstone/services/scryfall/api.py
@@ -9,7 +9,7 @@ from pydantic.error_wrappers import ValidationError
 from pydantic.networks import AnyUrl
 from typing_extensions import AsyncGenerator, Type, overload
 
-from mightstone.ass import compressor, synchronize
+from mightstone.ass import compressor, sync_generator, synchronize
 from mightstone.services import MightstoneHttpClient, ServiceError
 from mightstone.services.scryfall.models import (
     BulkTagType,
@@ -69,7 +69,7 @@ class Scryfall(MightstoneHttpClient):
             ):
                 yield Tag.parse_obj(current_tag)
 
-    get_bulk_tags = synchronize(get_bulk_tags_async)
+    get_bulk_tags = sync_generator(get_bulk_tags_async)
 
     async def get_bulk_data_async(self, bulk_type: str) -> AsyncGenerator[Card, None]:
         """
@@ -103,7 +103,7 @@ class Scryfall(MightstoneHttpClient):
             ):
                 yield Card.parse_obj(current_card)
 
-    get_bulk_data = synchronize(get_bulk_data_async)
+    get_bulk_data = sync_generator(get_bulk_data_async)
 
     async def card_async(
         self, id: str, type: CardIdentifierPath = CardIdentifierPath.SCRYFALL
@@ -197,7 +197,7 @@ class Scryfall(MightstoneHttpClient):
         ):
             yield item
 
-    search = synchronize(search_async)
+    search = sync_generator(search_async)
 
     async def named_async(self, q: str, set: str = None, exact=True) -> Card:
         """
@@ -294,7 +294,7 @@ class Scryfall(MightstoneHttpClient):
         ):
             yield item
 
-    collection = synchronize(collection_async)
+    collection = sync_generator(collection_async)
 
     async def rulings_async(
         self,
@@ -324,7 +324,7 @@ class Scryfall(MightstoneHttpClient):
         async for item in self._list(path, Ruling, limit=limit):
             yield item
 
-    rulings = synchronize(rulings_async)
+    rulings = sync_generator(rulings_async)
 
     async def symbols_async(self, limit: int = None) -> AsyncGenerator[Symbol, None]:
         """
@@ -337,7 +337,7 @@ class Scryfall(MightstoneHttpClient):
         async for item in self._list("/symbology", Symbol, limit=limit):
             yield item
 
-    symbols = synchronize(symbols_async)
+    symbols = sync_generator(symbols_async)
 
     async def parse_mana_async(self, cost: str) -> ManaCost:
         """
@@ -404,7 +404,7 @@ class Scryfall(MightstoneHttpClient):
         async for item in self._list("/migrations", Migration, limit=limit):
             yield item
 
-    migrations = synchronize(migrations_async)
+    migrations = sync_generator(migrations_async)
 
     async def migration_async(self, id: str) -> Migration:
         """
@@ -427,7 +427,7 @@ class Scryfall(MightstoneHttpClient):
         async for item in self._list("/sets", Set, limit=limit):
             yield item
 
-    sets = synchronize(sets_async)
+    sets = sync_generator(sets_async)
 
     async def set_async(self, id_or_code: str = None) -> Set:
         """
@@ -439,7 +439,7 @@ class Scryfall(MightstoneHttpClient):
         """
         return await self._get_item(f"/sets/{id_or_code}", Set)
 
-    set = synchronize(sets_async)
+    set = sync_generator(sets_async)
 
     @overload
     async def _get_item(self, path: str, model: None, **kwargs) -> Dict:


### PR DESCRIPTION
Fixes #28 .

Our implementation of `synchronize` based on `asgiref.async_to_sync` does not support async generator.
As suggested in [this thread](https://stackoverflow.com/questions/75914293/nested-async-to-sync-generator-stops-at-first-iteration-when-executing-each-iter), we use a `loop.run_until_complete` pattern.

In this PR we also fix `scryfall.random_async` method that did use a local cache and wasn’t that much random. :)