### PR TITLE
fix: applied updated card conjurer template

### DIFF
--- a/src/mightstone/services/cardconjurer/models.py
+++ b/src/mightstone/services/cardconjurer/models.py
@@ -332,7 +332,7 @@ class TemplateContext(MightstoneModel):
     each one down individually, in detail.
     """
 
-    ui: Any = None
+    license: Optional[dict] = None
     image_sets: List[TemplateContextImageSet] = Field(alias="imageSets", default=[])
     fonts: List[TemplateFont] = []
     symbol_sets: List[SymbolSet] = Field(alias="symbolSets", default=[])
@@ -356,7 +356,7 @@ class Template(MightstoneDocument):
     This allow to re-contextualize relative path and build proper urls
     """
 
-    metadata: TemplateMetaData
+    name: str
     context: TemplateContext
     card: Card
 
@@ -366,7 +366,7 @@ class Template(MightstoneDocument):
         :return: A dummy template, with nothing in it
         """
         return Template(
-            metadata=TemplateMetaData(),
+            name="Dummy",
             context=TemplateContext(),
             card=Card(name="Dummy", width=100, height=100),
         )

--- a/tests/services/cardconjurer/test_remote.py
+++ b/tests/services/cardconjurer/test_remote.py
@@ -24,7 +24,7 @@ class TestCardConjurerRemote(TestBeanie):
             "https://card-conjurer-assets.s3.us-east-1.amazonaws.com",
         )
 
-        self.assertEqual(template.metadata.name, "Angular")
+        self.assertEqual(template.name, "Angular")
         self.assertEqual(len(template.context.image_sets[0].variants), 8)
         self.assertEqual(
             template.context.image_sets[0].variants[0].name,
@@ -49,7 +49,7 @@ class TestCardConjurerRemote(TestBeanie):
             "https://card-conjurer-assets.s3.us-east-1.amazonaws.com",
         )
 
-        self.assertEqual(template.metadata.name, "Custom Frame Template")
+        # self.assertEqual(template.name, "Simple Tokens")
         self.assertEqual(len(template.context.image_sets[0].variants), 2)
         self.assertEqual(
             template.context.image_sets[0].variants[1].name,
@@ -69,7 +69,7 @@ class TestCardConjurerRemote(TestBeanie):
             template.asset_root_url,
             "https://card-conjurer-assets.s3.us-east-1.amazonaws.com",
         )
-        self.assertEqual(template.metadata.name, "Tall Archaic")
+        self.assertEqual(template.name, "Tall Archaic")
         self.assertEqual(len(template.context.image_sets[0].variants), 9)
         self.assertEqual(template.context.image_sets[0].variants[1].name, "Blue Frame")
         self.assertIsInstance(template.card, Card)


### PR DESCRIPTION
- metadata is removed
- name is part of root object