### PR TITLE
Attempt to fix release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -53,46 +51,3 @@ jobs:
     - name: Test with pytest
       run: |
         make test
-
-  release:
-    runs-on: ubuntu-latest
-    concurrency: release
-    permissions:
-      id-token: write
-      contents: write
-    needs: test
-    if: github.repository_owner == 'guibod' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    # https://github.community/t/how-do-i-specify-job-dependency-running-in-another-workflow/16482
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(release):')
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install poetry
-        uses: abatilo/actions-poetry@v2
-      - uses: actions/cache@v3
-        name: Define a cache for the virtual environment based on the dependencies lock file
-        with:
-          path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}
-      - name: Python Semantic Release
-        id: release
-        uses: python-semantic-release/python-semantic-release@v8.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
-        # See https://github.com/actions/runner/issues/1173
-        if: steps.release.outputs.released == 'true'
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-      - name: Publish package distributions to GitHub Releases
-        uses: python-semantic-release/upload-to-gh-release@main
-        if: steps.release.outputs.released == 'true'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,25 @@
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  pipy:
+    runs-on: ubuntu-latest
+    concurrency: release
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2
+      - name: Publish
+        run: poetry publish --build
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,0 +1,24 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency: release
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Python Semantic Release
+      uses: python-semantic-release/python-semantic-release@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,3 +1,0 @@
-[virtualenvs]
-in-project = true
-create = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,8 +138,7 @@ version_variable = ["src/mightstone/__init__.py:__version_", "docs/source/conf.p
 version_toml = ["pyproject.toml:tool.poetry.version"]
 branch = "main"
 build_command = "pip install poetry && make build"
-upload_to_pypi = true
-upload_to_release = true
+upload_to_vcs_release = true
 
 [tool.mypy]
 python_version = "3.9"


### PR DESCRIPTION
There was issues between `python-semantic-release` (move from fix version to master) and `poetry build` upon release.

In order to see through we now have a distinct workflow:

* On MR: run `ci.yml` (test + lint) before merging to main
* On push on Main: `semantic-release.yml`
* On release: `poetry publish --build`